### PR TITLE
Add email contact note

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,7 @@
           </button>
           <div id="formAlert" class="w3-panel w3-hide"></div>
         </form>
+        <p class="w3-center w3-margin-top">Prefer email? Reach me at <a href="mailto:zachary@example.com">zachary@example.com</a>.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add a mailto link in the contact section so visitors can reach out via email

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0627ee9488321ab1cb34edde07e9a

## Summary by Sourcery

New Features:
- Embed a mailto link in the contact section for direct email inquiries