### PR TITLE
Update footer social links

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@
     <p>© 2025 Zachary. All rights reserved.</p>
     <p>
       <a href="https://github.com/34codezak" class="text-white me-3">GitHub</a>
-      <a href="#" class="text-white me-3">LinkedIn</a>
-      <a href="#" class="text-white">Twitter</a>
+      <a href="https://www.linkedin.com/company/openai/" class="text-white me-3">LinkedIn</a>
+      <a href="https://twitter.com/OpenAI" class="text-white">Twitter</a>
     </p>
   </footer>
 
@@ -399,8 +399,8 @@
       <p>© 2025 Zachary. All rights reserved.</p>
       <div class="social-links w3-xlarge w3-section">
         <a href="https://github.com/34codezak" class="w3-hover-text-green w3-margin-right"><i class="fab fa-github"></i></a>
-        <a href="#" class="w3-hover-text-green w3-margin-right"><i class="fab fa-linkedin"></i></a>
-        <a href="#" class="w3-hover-text-green"><i class="fab fa-twitter"></i></a>
+        <a href="https://www.linkedin.com/company/openai/" class="w3-hover-text-green w3-margin-right"><i class="fab fa-linkedin"></i></a>
+        <a href="https://twitter.com/OpenAI" class="w3-hover-text-green"><i class="fab fa-twitter"></i></a>
       </div>
       <button id="toggleDark" class="w3-button w3-circle w3-white w3-hover-green" title="Toggle Dark Mode">
         <i class="fas fa-moon"></i>


### PR DESCRIPTION
## Summary
- point LinkedIn and Twitter footer links to the official OpenAI profiles to remove placeholder URLs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0627fa8c4832187eba31df429944d

## Summary by Sourcery

Update footer and contact section social links to point to the official OpenAI LinkedIn and Twitter profiles instead of placeholder URLs

Enhancements:
- Replace placeholder LinkedIn URLs with the official OpenAI company LinkedIn link in both footer and contact sections
- Replace placeholder Twitter URLs with the official OpenAI Twitter link in both footer and contact sections