### PR TITLE
Cache Firebase database reference for form submissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,6 +477,7 @@ const firebaseConfig = {
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);
 }
+const database = firebase.database();
 
 if (typeof firebase.analytics === 'function') {
   firebase.analytics();
@@ -496,13 +497,14 @@ contactForm.addEventListener('submit', (e) => {
     timestamp: new Date().toISOString()
   };
 
-  firebase.database().ref('contacts').push(submission)
+  database.ref('contacts').push(submission)
     .then(() => {
       formAlert.className = "w3-panel w3-green";
       formAlert.innerHTML = "<p>Message sent successfully!</p>";
       contactForm.reset();
     })
     .catch((error) => {
+      console.error('Failed to send message:', error);
       formAlert.className = "w3-panel w3-red";
       formAlert.innerHTML = `<p>Something went wrong: ${error.message}</p>`;
     });


### PR DESCRIPTION
## Summary
- initialize Firebase using the existing configuration and cache the database reference
- reuse the cached reference when pushing contact submissions
- log caught errors so failed writes are visible in the console

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d065e6bf688321b778797d405c9ecc

## Summary by Sourcery

Cache the Firebase Realtime Database reference on initialization to reuse it for contact form submissions and add console error logging for failed writes

Enhancements:
- Cache and reuse the Firebase database reference for contact form submissions
- Log errors to the console when message submissions fail