### PR TITLE
Configure admin Firebase dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -5,12 +5,36 @@
   <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-database.js"></script>
   <script>
-    firebase.initializeApp({ /* same config */ });
-    
+    const firebaseConfig = {
+      apiKey: "AIzaSyBty7-Ncgs2ABlIxXWybqhavT5FgnK9CBg",
+      authDomain: "p-web-db.firebaseapp.com",
+      projectId: "p-web-db",
+      storageBucket: "p-web-db.firebasestorage.app",
+      messagingSenderId: "762422687989",
+      appId: "1:762422687989:web:7b21e0e7a467f634cb6dbc",
+      measurementId: "G-4GSGV6NDC6"
+    };
+
+    if (!firebase.apps.length) {
+      firebase.initializeApp(firebaseConfig);
+    }
+
+    const messagesContainer = document.getElementById('messages');
+
     firebase.database().ref('contacts').on('value', (snapshot) => {
       const messages = snapshot.val();
-      document.getElementById('messages').innerHTML = 
-        JSON.stringify(messages, null, 2);
+
+      if (!messages) {
+        messagesContainer.textContent = 'No messages yet.';
+        return;
+      }
+
+      const items = Object.entries(messages)
+        .sort(([, a], [, b]) => new Date(b.timestamp) - new Date(a.timestamp))
+        .map(([, value]) => `• ${value.name} <${value.email}>\n  ${value.message}\n  Sent: ${new Date(value.timestamp).toLocaleString()}`)
+        .join('\n\n');
+
+      messagesContainer.textContent = items;
     });
   </script>
 </head>


### PR DESCRIPTION
## Summary
- configure the admin page to use the real Firebase configuration shared with the main site
- guard Firebase initialization from running more than once
- render retrieved contact messages in a readable list that falls back to a friendly empty state

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d065e84d9c83219d55b2a1a47fcdc2

## Summary by Sourcery

Configure the admin dashboard to connect to real Firebase settings, ensure single initialization, and improve message rendering with sorting and a fallback empty state.

Enhancements:
- Use the real Firebase project configuration on the admin page.
- Guard Firebase initialization to run only once.
- Render contact messages as a sorted, human-readable bullet list with a friendly empty state when there are no messages.