### PR TITLE
Enable dark mode stylesheet

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -96,63 +96,81 @@ footer a:hover {
   color: white;
 }
 
-/*Dark mode 
+/* Dark mode */
 body.dark-mode {
-  background-color: #333;
+  background-color: #121212;
   color: #e0e0e0;
 }
 
-body.dark-mode h1, body.dark-mode h2, body.dark-mode h3 {
-  color: #bbb;
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+  color: #f0f0f0;
 }
 
 body.dark-mode .hero {
-  background: linear-gradient(to right, #6a11cb, #2575fc);
-  color: #ccc;
-  padding: 6rem 0;
-  text-align: center;
+  background: linear-gradient(to right, #431182, #0f3460);
+  color: #f0f0f0;
 }
 
-body.dark-mode .navbar, body.dark-mode footer {
-  background-color: #1e1e1e;
-  color: #fff;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+body.dark-mode .navbar,
+body.dark-mode footer,
+body.dark-mode .w3-theme,
+body.dark-mode .w3-theme-dark {
+  background-color: #1e1e1e !important;
+  color: #f0f0f0 !important;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
 }
 
-body.dark-mode .card{
-    background-color: #222;
-    color: #fff;
+body.dark-mode .content-overlay {
+  background-color: rgba(0, 0, 0, 0.85);
+  color: #f0f0f0;
 }
 
-body.dark-mode #resume .btn {
+body.dark-mode .w3-theme-light,
+body.dark-mode .card {
+  background-color: rgba(30, 30, 30, 0.9) !important;
+  color: #f0f0f0 !important;
+}
+
+body.dark-mode .w3-button,
+body.dark-mode .btn {
   background-color: #2575fc;
-  color: white;
+  color: #ffffff !important;
+  border-color: #2575fc;
 }
 
-body.dark-mode container{
-  background: #333;
-  color: white;
+body.dark-mode .w3-button:hover,
+body.dark-mode .btn:hover {
+  background-color: #0d47a1;
+  color: #ffffff !important;
 }
 
 body.dark-mode a {
-    color: #90caf9
+  color: #90caf9;
 }
 
 body.dark-mode a:hover {
-    color: #90caf9
+  color: #bbdefb;
 }
 
-body.dark-mode form input, body.dark-mode form textarea {
-  background-color: #333;
-  color: #fff;
+body.dark-mode form input,
+body.dark-mode form textarea,
+body.dark-mode .w3-input {
+  background-color: #1e1e1e !important;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.3) !important;
 }
 
-body.dark-mode form input:focus, body.dark-mode form textarea:focus {
-  border-color: #2575fc;
-  box-shadow: 0 0 0 0.2rem rgba(37, 117, 252, 0.25);
+body.dark-mode form input:focus,
+body.dark-mode form textarea:focus,
+body.dark-mode .w3-input:focus {
+  border-color: #64b5f6 !important;
+  box-shadow: 0 0 0 0.2rem rgba(100, 181, 246, 0.25);
 }
 
-body.dark-mode #about {
-  padding: 5rem 0;
-  background-color: #333;
-}*/
+body.dark-mode #resume .btn,
+body.dark-mode #resume .w3-button {
+  background-color: #1976d2;
+  color: #ffffff !important;
+}

--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
   <!-- Fonts and Icons -->
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="css/styles.css">
   <!-- AOS Animation -->
   <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet" />
   <style>


### PR DESCRIPTION
## Summary
- load the shared css bundle on the portfolio page so custom styles apply
- reactivate and expand the dark mode overrides to restyle the overlay, buttons, and form inputs when toggled

## Testing
- python3 -m http.server 8000 (manually verified dark mode toggle)


------
https://chatgpt.com/codex/tasks/task_e_68d065e9332c8321b670c0bc8c4b0f6b