### PR TITLE
Fix contact form input handling and confirmation copy

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,13 +1,14 @@
 document.getElementById("contactForm").addEventListener("submit", function (e) {
     e.preventDefault();
-    const name = document.getElementById("name").ariaValueMax.trim();
-    const email = document.getElementById("email").ariaValueMax.trim();
-    const message = document.getElementById("message").ariaValueMax.trim();
+    e.stopImmediatePropagation();
+    const name = document.getElementById("name").value.trim();
+    const email = document.getElementById("email").value.trim();
+    const message = document.getElementById("message").value.trim();
 
     if (name && email && message) {
         document.getElementById("formAlert").innerHTML = `
             <div class="alert alert-success" role="alert">
-                Thank you for your message, " + name + ". I will get back to you soon.
+                Thank you for your message, ${name}. I will get back to you soon.
             </div>
         `;
         this.reset();


### PR DESCRIPTION
## Summary
- read contact form input values using `.value.trim()` to remove accidental whitespace before validation
- fix the thank-you message template literal so the visitor name renders correctly
- stop other submit listeners from overriding the success alert by halting propagation after our handler runs

## Testing
- node (manual DOM harness for contact form submit handler)


------
https://chatgpt.com/codex/tasks/task_e_68d0f04ae6408321ad925185f61d7217