### PR TITLE
Implement persistent dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,24 +449,60 @@
     
     // Dark mode toggle icon state
     const darkToggle = document.getElementById('toggleDark');
-    if (darkToggle) {
-      const updateIconState = () => {
-        const icon = darkToggle.querySelector('i');
-        if (!icon) {
-          return;
-        }
 
-        if (document.body.classList.contains('dark-mode')) {
-          icon.classList.remove('fa-moon');
-          icon.classList.add('fa-sun');
-        } else {
-          icon.classList.remove('fa-sun');
-          icon.classList.add('fa-moon');
-        }
-      };
+    const updateIconState = () => {
+      if (!darkToggle) {
+        return;
+      }
 
-      darkToggle.addEventListener('click', updateIconState);
+      const icon = darkToggle.querySelector('i');
+      if (!icon) {
+        return;
+      }
+
+      const isDark = document.body.classList.contains('dark-mode');
+      icon.classList.toggle('fa-sun', isDark);
+      icon.classList.toggle('fa-moon', !isDark);
+    };
+
+    const storeTheme = (isDark) => {
+      try {
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      } catch (error) {
+        // localStorage may be unavailable; fail silently.
+      }
+    };
+
+    const applyStoredTheme = () => {
+      let savedTheme;
+      try {
+        savedTheme = localStorage.getItem('theme');
+      } catch (error) {
+        savedTheme = null;
+      }
+
+      if (savedTheme === 'dark') {
+        document.body.classList.add('dark-mode');
+      } else if (savedTheme === 'light') {
+        document.body.classList.remove('dark-mode');
+      }
+
+      if (darkToggle) {
+        darkToggle.setAttribute('aria-pressed', String(document.body.classList.contains('dark-mode')));
+      }
+
       updateIconState();
+    };
+
+    applyStoredTheme();
+
+    if (darkToggle) {
+      darkToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark-mode');
+        darkToggle.setAttribute('aria-pressed', String(isDark));
+        storeTheme(isDark);
+        updateIconState();
+      });
     }
 
   </script>


### PR DESCRIPTION
## Summary
- update the theme toggle script to actually switch the dark-mode class on the body
- persist the chosen theme in localStorage and sync the toggle icon/aria state on load and on click

## Testing
- Not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68d0f456290883219a7b779623d52e2a