### PR TITLE
Add borders to project cards for light and dark modes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,7 +45,7 @@ h1, h2, h3 {
 
 /* Projects */
 .card {
-  border: none;
+  border: 1px solid #2575fc;
   border-radius: 12px;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
   transition: transform 0.3s ease;
@@ -131,6 +131,7 @@ body.dark-mode .w3-theme-light,
 body.dark-mode .card {
   background-color: rgba(30, 30, 30, 0.9) !important;
   color: #f0f0f0 !important;
+  border: 1px solid #64b5f6;
 }
 
 body.dark-mode .w3-button,


### PR DESCRIPTION
## Summary
- add a 1px accent border to project cards in the default theme
- ensure project card borders remain visible in dark mode with a lighter hue

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0f4f2f3608321b856769cd6cbb8ee