### PR TITLE
Improve dark mode styling consistency

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -147,6 +147,24 @@ body.dark-mode .btn:hover {
   color: #ffffff !important;
 }
 
+body.dark-mode .w3-button.w3-white,
+body.dark-mode .w3-white,
+body.dark-mode .w3-hover-white:hover,
+body.dark-mode .w3-button.w3-white:hover,
+body.dark-mode .w3-button.w3-white:focus {
+  background-color: #1f1f1f !important;
+  color: #f0f0f0 !important;
+  border-color: #64b5f6 !important;
+  box-shadow: 0 0 0 1px rgba(100, 181, 246, 0.4);
+}
+
+body.dark-mode .w3-button.w3-white:hover,
+body.dark-mode .w3-button.w3-white:focus {
+  background-color: #1976d2 !important;
+  color: #ffffff !important;
+  box-shadow: 0 0 0 1px rgba(25, 118, 210, 0.6);
+}
+
 body.dark-mode a {
   color: #90caf9;
 }
@@ -173,5 +191,41 @@ body.dark-mode .w3-input:focus {
 body.dark-mode #resume .btn,
 body.dark-mode #resume .w3-button {
   background-color: #1976d2;
+  color: #ffffff !important;
+}
+
+body.dark-mode .w3-panel.w3-green {
+  background-color: #1b5e20 !important;
+  color: #c8e6c9 !important;
+  border-color: transparent !important;
+}
+
+body.dark-mode .w3-panel.w3-red {
+  background-color: #b71c1c !important;
+  color: #ffcdd2 !important;
+  border-color: transparent !important;
+}
+
+body.dark-mode .w3-border {
+  border-color: rgba(144, 202, 249, 0.4) !important;
+}
+
+body.dark-mode .social-links a {
+  color: #bbdefb !important;
+}
+
+body.dark-mode .social-links a:hover {
+  color: #90caf9 !important;
+}
+
+body.dark-mode #toggleDark {
+  background-color: #1976d2 !important;
+  color: #ffffff !important;
+  box-shadow: 0 6px 16px rgba(13, 71, 161, 0.45);
+}
+
+body.dark-mode #toggleDark:hover,
+body.dark-mode #toggleDark:focus {
+  background-color: #0d47a1 !important;
   color: #ffffff !important;
 }


### PR DESCRIPTION
## Summary
- smooth out the dark-mode treatment for W3.CSS components so white variants no longer flash bright backgrounds
- restyle success/error alerts, social icons, and the floating toggle to better match the dark palette

## Testing
- python3 -m http.server 8000 (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68d0f68759d48321b8eba3f200cf5757

## Summary by Sourcery

Enhance dark mode styling consistency across W3.CSS components and custom elements

Enhancements:
- Override .w3-white button variants in dark mode with dark backgrounds, light text, accent borders, and hover states
- Restyle success and error alert panels (.w3-panel.w3-green/.w3-red) in dark mode with deeper backgrounds and subtle text colors
- Standardize border colors and shadows for W3.CSS elements in dark mode
- Adjust social icons and the floating dark-mode toggle button for improved contrast and consistent hover effects