### PR TITLE
Improve contact form submission feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,13 @@ if (typeof firebase.analytics === 'function') {
   firebase.analytics();
 }
 
-const db = firebase.firestore();
+let db;
+try {
+  db = firebase.firestore();
+} catch (error) {
+  console.error('Failed to initialize Firestore:', error);
+}
+
 const contactForm = document.getElementById('contactForm');
 const formAlert = document.getElementById('formAlert');
 
@@ -602,6 +608,22 @@ const toggleSubmitState = (isSubmitting) => {
   }
 };
 
+const withTimeout = (promise, timeoutMs, timeoutMessage) => new Promise((resolve, reject) => {
+  const timer = setTimeout(() => {
+    reject(new Error(timeoutMessage || 'Request timed out. Please try again.'));
+  }, timeoutMs);
+
+  promise
+    .then((value) => {
+      clearTimeout(timer);
+      resolve(value);
+    })
+    .catch((error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+});
+
 if (contactForm && formAlert) {
   contactForm.addEventListener('submit', async (event) => {
     event.preventDefault();
@@ -615,15 +637,24 @@ if (contactForm && formAlert) {
       return;
     }
 
+    if (!db || typeof db.collection !== 'function') {
+      applyAlertStyles('error', 'Unable to send your message right now. Please try again later.');
+      return;
+    }
+
     toggleSubmitState(true);
 
     try {
-      await db.collection('contacts').add({
-        name,
-        email,
-        message,
-        timestamp: firebase.firestore.FieldValue.serverTimestamp()
-      });
+      await withTimeout(
+        db.collection('contacts').add({
+          name,
+          email,
+          message,
+          timestamp: firebase.firestore.FieldValue.serverTimestamp()
+        }),
+        10000,
+        'The request is taking longer than expected. Please check your connection and try again.'
+      );
 
       applyAlertStyles('success', 'Message sent successfully!');
       contactForm.reset();


### PR DESCRIPTION
## Summary
- guard Firestore initialization to avoid leaving the form in a pending state when Firebase fails to load
- add a timeout helper so the submit button is re-enabled if Firestore calls take too long
- provide a user-friendly alert when the contact service is unavailable

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0f7716f048321a9d2bc4d09ed60b1

## Summary by Sourcery

Improve the contact form submission by handling Firestore initialization failures, adding a timeout for database calls, and showing clear error alerts when the service is unavailable or slow.

Bug Fixes:
- Prevent the contact form from remaining in a pending state when Firestore fails to initialize

Enhancements:
- Wrap Firestore initialization in try-catch to gracefully handle loading failures
- Introduce a withTimeout helper to reject database requests that exceed 10 seconds
- Display an error alert and re-enable the submit button if Firestore is unavailable or a request times out