### PR TITLE
Redirect contact form submissions to Gmail compose

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -5,16 +5,42 @@ document.getElementById("contactForm").addEventListener("submit", function (e) {
     const email = document.getElementById("email").value.trim();
     const message = document.getElementById("message").value.trim();
 
-    if (name && email && message) {
-        document.getElementById("formAlert").innerHTML = `
+    const alertContainer = document.getElementById("formAlert");
+
+    if (!name || !email || !message) {
+        if (alertContainer) {
+            alertContainer.innerHTML = "<div class='alert alert-danger'>Please fill in all fields.</div>";
+        }
+        return;
+    }
+
+    const recipient = "zachary@example.com";
+    const gmailUrl = new URL("https://mail.google.com/mail/");
+    gmailUrl.searchParams.set("view", "cm");
+    gmailUrl.searchParams.set("fs", "1");
+    gmailUrl.searchParams.set("to", recipient);
+    gmailUrl.searchParams.set("su", `Portfolio inquiry from ${name}`);
+    gmailUrl.searchParams.set(
+        "body",
+        [`Name: ${name}`, `Email: ${email}`, "", message].join("\n")
+    );
+
+    const gmailHref = gmailUrl.toString();
+    const gmailWindow = window.open(gmailHref, "_blank", "noopener");
+
+    if (!gmailWindow) {
+        window.location.href = gmailHref;
+    }
+
+    if (alertContainer) {
+        alertContainer.innerHTML = `
             <div class="alert alert-success" role="alert">
-                Thank you for your message, ${name}. I will get back to you soon.
+                Redirecting you to Gmail. If nothing opens, <a href="${gmailHref}" target="_blank" rel="noopener">click here</a>.
             </div>
         `;
-        this.reset();
-    } else {
-        document.getElementById("formAlert").innerHTML = "<div class='alert alert-danger'>Please fill in all fields.</div>";
     }
+
+    this.reset();
 });
 
 const toggleDark = document.getElementById("toggleDark");


### PR DESCRIPTION
## Summary
- update the contact form handler to build a Gmail compose link with the sender's details
- attempt to open Gmail in a new tab with a fallback redirect and user-facing instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0f7b82cbc832190db583df4329242

## Summary by Sourcery

Implement a Gmail compose redirect for contact form submissions, adding form validation, fallback behavior, and inline user notifications

New Features:
- Redirect contact form submissions to a Gmail compose window with prefilled recipient, subject, and body parameters

Enhancements:
- Add client-side validation for name, email, and message fields with inline success or error alerts
- Provide a fallback redirect and user-facing instruction link when Gmail fails to open
- Reset the form after handling submission