### PR TITLE
Adjust dark mode styling to use dark green palette

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -109,7 +109,7 @@ body.dark-mode h3 {
 }
 
 body.dark-mode .hero {
-  background: linear-gradient(to right, #431182, #0f3460);
+  background: linear-gradient(to right, #2c5234, #174a2a);
   color: #f0f0f0;
 }
 
@@ -131,19 +131,19 @@ body.dark-mode .w3-theme-light,
 body.dark-mode .card {
   background-color: rgba(30, 30, 30, 0.9) !important;
   color: #f0f0f0 !important;
-  border: 1px solid #64b5f6;
+  border: 1px solid #66bb6a;
 }
 
 body.dark-mode .w3-button,
 body.dark-mode .btn {
-  background-color: #2575fc;
+  background-color: #2e7d32;
   color: #ffffff !important;
-  border-color: #2575fc;
+  border-color: #2e7d32;
 }
 
 body.dark-mode .w3-button:hover,
 body.dark-mode .btn:hover {
-  background-color: #0d47a1;
+  background-color: #1b5e20;
   color: #ffffff !important;
 }
 
@@ -154,23 +154,23 @@ body.dark-mode .w3-button.w3-white:hover,
 body.dark-mode .w3-button.w3-white:focus {
   background-color: #1f1f1f !important;
   color: #f0f0f0 !important;
-  border-color: #64b5f6 !important;
-  box-shadow: 0 0 0 1px rgba(100, 181, 246, 0.4);
+  border-color: #66bb6a !important;
+  box-shadow: 0 0 0 1px rgba(102, 187, 106, 0.4);
 }
 
 body.dark-mode .w3-button.w3-white:hover,
 body.dark-mode .w3-button.w3-white:focus {
-  background-color: #1976d2 !important;
+  background-color: #2e7d32 !important;
   color: #ffffff !important;
-  box-shadow: 0 0 0 1px rgba(25, 118, 210, 0.6);
+  box-shadow: 0 0 0 1px rgba(46, 125, 50, 0.6);
 }
 
 body.dark-mode a {
-  color: #90caf9;
+  color: #a5d6a7;
 }
 
 body.dark-mode a:hover {
-  color: #bbdefb;
+  color: #c8e6c9;
 }
 
 body.dark-mode form input,
@@ -184,13 +184,13 @@ body.dark-mode .w3-input {
 body.dark-mode form input:focus,
 body.dark-mode form textarea:focus,
 body.dark-mode .w3-input:focus {
-  border-color: #64b5f6 !important;
-  box-shadow: 0 0 0 0.2rem rgba(100, 181, 246, 0.25);
+  border-color: #66bb6a !important;
+  box-shadow: 0 0 0 0.2rem rgba(102, 187, 106, 0.25);
 }
 
 body.dark-mode #resume .btn,
 body.dark-mode #resume .w3-button {
-  background-color: #1976d2;
+  background-color: #2e7d32;
   color: #ffffff !important;
 }
 
@@ -207,25 +207,25 @@ body.dark-mode .w3-panel.w3-red {
 }
 
 body.dark-mode .w3-border {
-  border-color: rgba(144, 202, 249, 0.4) !important;
+  border-color: rgba(165, 214, 167, 0.4) !important;
 }
 
 body.dark-mode .social-links a {
-  color: #bbdefb !important;
+  color: #c8e6c9 !important;
 }
 
 body.dark-mode .social-links a:hover {
-  color: #90caf9 !important;
+  color: #a5d6a7 !important;
 }
 
 body.dark-mode #toggleDark {
-  background-color: #1976d2 !important;
+  background-color: #2e7d32 !important;
   color: #ffffff !important;
-  box-shadow: 0 6px 16px rgba(13, 71, 161, 0.45);
+  box-shadow: 0 6px 16px rgba(27, 94, 32, 0.45);
 }
 
 body.dark-mode #toggleDark:hover,
 body.dark-mode #toggleDark:focus {
-  background-color: #0d47a1 !important;
+  background-color: #1b5e20 !important;
   color: #ffffff !important;
 }


### PR DESCRIPTION
## Summary
- replace dark mode accent colors with a cohesive dark green palette
- update button, link, and hero styles to match the new dark green scheme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10c90580083218a824d7ddc8db0b3

## Summary by Sourcery

Switch dark mode accent colors from blue to a unified dark green palette across the site

Enhancements:
- Replace dark mode hero gradient with dark green tones
- Update button, hover, and toggle styles to use green backgrounds and borders
- Adjust link, social icon, card border, and form input focus colors to the new green palette