### PR TITLE
Update contact form recipient address

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -14,7 +14,7 @@ document.getElementById("contactForm").addEventListener("submit", function (e) {
         return;
     }
 
-    const recipient = "zachary@example.com";
+    const recipient = "kmoniprojects@gmail.com";
     const gmailUrl = new URL("https://mail.google.com/mail/");
     gmailUrl.searchParams.set("view", "cm");
     gmailUrl.searchParams.set("fs", "1");


### PR DESCRIPTION
## Summary
- replace the contact form's placeholder email recipient with the live kmoniprojects@gmail.com address so Gmail drafts go to the right inbox

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1a87ce76483218f6f72e9884011f9