### PR TITLE
Align Node tooling with Vite 7 requirements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+          publish_dir: ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project contains a static portfolio site powered by HTML, CSS, and vanilla 
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 18 or newer (the Dockerfile uses Node.js 20)
+- [Node.js](https://nodejs.org/) 22 or newer (the tooling and Dockerfile target Node.js 22)
 - npm (bundled with Node.js)
 - [Docker](https://www.docker.com/) if you plan to build the production image locally
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "devDependencies": {
     "vite": "^7.1.7"
   }


### PR DESCRIPTION
## Summary
- update the Docker build stage to use the Node.js 22 alpine image that satisfies Vite 7's engine requirements
- declare the Node.js 22+ engine requirement in package.json and README documentation
- expand the deploy workflow to install dependencies, build the site, and publish the dist directory using Node.js 22

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2296da0f08321a0a537308b0c3b16

## Summary by Sourcery

Align Node.js tooling with Vite 7 engine requirements by upgrading to Node.js 22 across CI, Docker, package metadata, and documentation, and adjust the deployment workflow accordingly

Enhancements:
- Declare engines.node >=22.0.0 in package.json

Build:
- Update Dockerfile base image to node:22-alpine

CI:
- Bump GitHub Actions checkout to v4 and add setup-node@v4 with Node.js 22 and npm cache
- Install dependencies and run build before deploying to GitHub Pages
- Change publish directory to ./dist in the deployment workflow

Documentation:
- Update README to require Node.js 22 or newer